### PR TITLE
[FIX] 만료된 refresh 토큰 사용 시 발생하는 예외 변경 #93

### DIFF
--- a/backend/account/serializers.py
+++ b/backend/account/serializers.py
@@ -13,6 +13,7 @@ from config.exceptions import (
     InvalidAccountException,
     InvalidFieldException,
     InvalidFieldStateException,
+    InvalidRefreshTokenException,
 )
 
 
@@ -353,7 +354,7 @@ class CustomTokenRefreshSerializer(TokenRefreshSerializer):
         try:
             data = super().validate(attrs)
         except TokenError as e:
-            raise serializers.ValidationError("토큰이 유효하지 않습니다.")
+            raise InvalidRefreshTokenException("토큰이 유효하지 않습니다.")
 
         return data
 

--- a/backend/config/exceptions.py
+++ b/backend/config/exceptions.py
@@ -32,6 +32,12 @@ class InvalidAccountException(APIException):
     default_code = "invalid_account"
 
 
+class InvalidRefreshTokenException(APIException):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_detail = "유효하지 않은 리프레쉬 토큰입니다."
+    default_code = "invalid_refresh_token"
+
+
 class PermissionFailedException(APIException):
     status_code = status.HTTP_403_FORBIDDEN
     default_detail = "이 작업을 수행할 권한이 없습니다."


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #93 

## 📝 작업 내용

> InvalidRefreshTokenException 생성
> 유효하지 않는 refresh 토큰 사용 시 발생하는 예외 변경