### PR TITLE
[FIX] 랭킹 스케쥴러가 저번주 랭킹을 제대로 계산하지 못하는 문제 해결

### DIFF
--- a/backend/ranking/jobs.py
+++ b/backend/ranking/jobs.py
@@ -18,10 +18,10 @@ def get_week_start_end(target_date_utc: datetime = datetime.now(pytz.utc), zone:
         timezone = pytz.timezone(zone)
     except pytz.UnknownTimeZoneError:
         raise ValueError("Unknown timezone")
-    current_date_in_timezone: datetime = target_date_utc.astimezone(timezone)
+    target_date_in_timezone: datetime = target_date_utc.astimezone(timezone)
 
     # Calculate the start of the week (Monday).
-    start_of_week = current_date_in_timezone - timedelta(days=current_date_in_timezone.weekday())
+    start_of_week = target_date_in_timezone - timedelta(days=target_date_in_timezone.weekday())
     # Calculate the end of the week (Sunday).
     end_of_week = start_of_week + timedelta(days=6)
 

--- a/backend/ranking/jobs.py
+++ b/backend/ranking/jobs.py
@@ -61,7 +61,7 @@ def compile_rankings(target_date_utc: datetime = datetime.now(pytz.utc)) -> tupl
         .order_by("-total_score")
     )
 
-    year_week_day = tuple(target_date_utc.isocalendar())
+    year_week_day = tuple(monday_datetime.isocalendar())
 
     # remove previous rankings for the same week
     delete_rankings(Ranking.CUR_GENERATION, year_week_day[1])


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #144 

## 📝 작업 내용

> 랭킹 집계 시, week column의 값을 Time Zone을 고려하여 계산하게 변경