### PR TITLE
[FIX] 마이페이지 출석 통계 조회 시 NULL을 반환하는 문제 해결 #215

### DIFF
--- a/backend/mypage/schemas.py
+++ b/backend/mypage/schemas.py
@@ -24,8 +24,22 @@ MYPAGE_RESPONSE_EXAMPLE = OpenApiExample(
                 "profile_number": 8,
                 "introduction": "안녕하십니까",
             },
-            "total_workout_time": 220,
-            "records": [{"workout_level": "파란색", "total_count": 6}],
+            "total_workout_time": 600,
+            "records": [
+                {
+                    "workout_level": "파란색",
+                    "total_count": 1,
+                },
+                {
+                    "workout_level": "빨간색",
+                    "total_count": 4,
+                },
+            ],
+            "attendance_stats": {
+                "attendance": 2,
+                "late": 1,
+                "absence": 0,
+            },
         },
     },
     response_only=True,

--- a/backend/mypage/serializers.py
+++ b/backend/mypage/serializers.py
@@ -106,7 +106,14 @@ class MypageSerializer(serializers.ModelSerializer):
             return {}
 
         attendance_stats = AttendanceStats.objects.filter(user=obj, generation=self.current_generation).first()
-        return AttendanceStatsSerializer(attendance_stats).data if attendance_stats else {}
+        if attendance_stats:
+            return AttendanceStatsSerializer(attendance_stats).data
+        else:
+            return {
+                "attendance": 0,
+                "late": 0,
+                "absence": 0,
+            }
 
 
 @extend_schema_serializer(examples=USER_UPDATE_REQUEST_EXAMPLE)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #215 

## 📝 작업 내용

> 마이페이지 조회에서 출석 통계 테이블이 존재하지 않으면 모든 필드를 0으로 반환하도록 수정