### PR TITLE
[FIX] Redis가 레플리카로 전환되어 Celery와의 연결이 끊기는 문제 해결 #227

### DIFF
--- a/backend/config/celery.py
+++ b/backend/config/celery.py
@@ -11,6 +11,7 @@ app = Celery("worker")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 app.conf.timezone = "Asia/Seoul"
+app.conf.broker_connection_retry_on_startup = True
 
 app.conf.beat_schedule = {
     "reject_pending_attendances": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,9 @@ services:
         image: redis:7
         ports:
             - "6379:6379"
+        volumes:
+            - ./redis.conf:/usr/local/etc/redis/redis.conf
+        command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
 
     worker:
         container_name: celery

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,5 @@
+protected-mode yes
+requirepass new_password_1234
+replica-serve-stale-data no
+replicaof no one
+slave-read-only yes


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #227 

## 📝 작업 내용

> Celery 설정 추가
> Redis 설정 추가 및 docker compose에서 Redis 설정을 참조하도록 수정