### PR TITLE
[FIX] 결석 처리 관련 에러 해결 #236

### DIFF
--- a/backend/attendance/admin.py
+++ b/backend/attendance/admin.py
@@ -35,7 +35,7 @@ class AttendanceAdmin(admin.ModelAdmin):
         "generation",
         "week",
         "attendance_status",
-        "workout_location",
+        "get_workout_location",
         "request_time",
         "request_processed_status",
         "request_processed_time",
@@ -61,6 +61,11 @@ class AttendanceAdmin(admin.ModelAdmin):
         return "-"
 
     get_request_processed_user_name.short_description = "처리한 운영진"
+
+    def get_workout_location(self, obj):
+        if obj.workout_location:
+            return obj.workout_location
+        return "-"
 
 
 @admin.register(AttendanceStats)

--- a/backend/attendance/tasks.py
+++ b/backend/attendance/tasks.py
@@ -101,6 +101,7 @@ def absence_processing():
 
         users = User.objects.filter(
             generation__name__in=[previous_generation_name, current_generation.name],
+            role="부원",
         )
 
         with transaction.atomic():

--- a/backend/attendance/tasks.py
+++ b/backend/attendance/tasks.py
@@ -3,10 +3,16 @@ from datetime import datetime
 from typing import Optional
 
 from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from account.models import Generation, User
-from attendance.models import Attendance, UnavailableDates, WeeklyStaffInfo
+from attendance.models import (
+    Attendance,
+    AttendanceStats,
+    UnavailableDates,
+    WeeklyStaffInfo,
+)
 from attendance.services import get_day_of_week, get_weeks_since_start
 from config.celery import app
 
@@ -121,3 +127,10 @@ def absence_processing():
                         request_processed_status="승인",
                         attendance_status="결석",
                     )
+
+                    attendance_stats, created = AttendanceStats.objects.get_or_create(
+                        user=user,
+                        generation=current_generation,
+                    )
+                    attendance_stats.absence = F("absence") + 1
+                    attendance_stats.save()

--- a/backend/attendance/tasks.py
+++ b/backend/attendance/tasks.py
@@ -102,6 +102,7 @@ def absence_processing():
         users = User.objects.filter(
             generation__name__in=[previous_generation_name, current_generation.name],
             role="부원",
+            is_active=True,
         )
 
         with transaction.atomic():


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #236 

## 📝 작업 내용

> 활성화된 부원만 결석 처리하도록 수정
> 출석 어드민에서 운동 지점이 없는 경우에 대한 처리
> 결석 처리 테스크에서 출석 통계 테이블 업데이트 로직 추가
